### PR TITLE
Remove reference to master branch

### DIFF
--- a/src/content/3/zh/part3a.md
+++ b/src/content/3/zh/part3a.md
@@ -1028,8 +1028,8 @@ important: body.important || false,
 您可以在[这个 github 仓库](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1)的<i>part3-1</i> 分支中找到我们当前应用的全部代码。
 
 
-<!-- Notice that the master branch of the repository contains the code from a later version of the application. The code for the current state of the application is specifically in branch [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1). -->
-注意，仓库的主分支包含应用的后一个版本的代码。 应用当前状态的代码单独在 branch [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1)中。
+<!-- The code for the current state of the application is specifically in branch [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1). -->
+应用当前状态的代码单独在 branch [part3-1](https://github.com/fullstack-hy/part3-notes-backend/tree/part3-1)中。
 
 ![](../../images/3/21.png)
 


### PR DESCRIPTION
Remove reference to master branch because it does not exist.
Instead, the default branch in the repository is part3-1.